### PR TITLE
Added Spanish names and surnames

### DIFF
--- a/src/names/es.ts
+++ b/src/names/es.ts
@@ -1,0 +1,18 @@
+const spanishNames = {
+    0: [ // Male names - Sources: https://www.ine.es/, https://www.rae.es/, https://forebears.io/, https://www.behindthename.com/, https://mydailyspanish.com/, https://www.familyeducation.com/
+        'Alejandro', 'Álvaro', 'Antonio', 'Carlos', 'Daniel', 'David', 'Diego', 'Eduardo', 'Enrique', 'Felipe',
+        'Fernando', 'Francisco', 'Gabriel', 'Gonzalo', 'Guillermo', 'Héctor', 'Hugo', 'Ignacio', 'Iván', 'Javier',
+        'Jorge', 'José', 'Juan', 'Julio', 'Lorenzo', 'Luis', 'Manuel', 'Marcos', 'Mario', 'Martín',
+        'Mateo', 'Miguel', 'Nicolás', 'Oscar', 'Pablo', 'Pedro', 'Rafael', 'Raúl', 'Ricardo', 'Roberto',
+        'Rodrigo', 'Rubén', 'Salvador', 'Samuel', 'Santiago', 'Sergio', 'Tomás', 'Víctor', 'Vicente', 'Xavier'
+    ],
+    1: [ // Female names - Sources: https://www.ine.es/, https://www.rae.es/, https://forebears.io/, https://www.behindthename.com/, https://mydailyspanish.com/, https://www.familyeducation.com/
+        'Adriana', 'Alejandra', 'Alicia', 'Ana', 'Andrea', 'Beatriz', 'Carla', 'Carmen', 'Carolina', 'Catalina',
+        'Claudia', 'Cristina', 'Daniela', 'Diana', 'Elena', 'Elisa', 'Emma', 'Eva', 'Fátima', 'Gabriela',
+        'Gloria', 'Irene', 'Isabel', 'Laura', 'Lucía', 'María', 'Marina', 'Marta', 'Mónica', 'Natalia',
+        'Noelia', 'Olivia', 'Paula', 'Raquel', 'Rebeca', 'Rita', 'Rosa', 'Sandra', 'Sofía', 'Sonia',
+        'Susana', 'Tamara', 'Teresa', 'Ursula', 'Valeria', 'Vanessa', 'Victoria', 'Virginia', 'Ximena', 'Yolanda'
+    ]
+}
+
+export default spanishNames;

--- a/src/surnames/es.ts
+++ b/src/surnames/es.ts
@@ -1,0 +1,9 @@
+const spanishSurnames = [ // Sources: https://www.ine.es/, https://www.rae.es/, https://forebears.io/, https://www.behindthename.com/, https://mydailyspanish.com/, https://www.familyeducation.com/
+    'Alonso', 'Alvarez', 'Blanco', 'Bravo', 'Cabello', 'Calderón', 'Campos', 'Castillo', 'Castro', 'Cruz',
+    'Díaz', 'Domínguez', 'Fernández', 'Flores', 'García', 'Gómez', 'González', 'Guerrero', 'Gutiérrez', 'Hernández',
+    'Jiménez', 'López', 'Martínez', 'Medina', 'Mendoza', 'Molina', 'Montes', 'Moreno', 'Muñoz', 'Navarro',
+    'Nieto', 'Núñez', 'Ortiz', 'Pérez', 'Ramírez', 'Reyes', 'Rivera', 'Rodríguez', 'Romero', 'Ruiz',
+    'Sánchez', 'Santos', 'Silva', 'Soto', 'Suarez', 'Torres', 'Vargas', 'Vázquez', 'Vega', 'Vera'
+];
+
+export default spanishSurnames;


### PR DESCRIPTION
- Added 50 common male and female Spanish names, and 50 common Spanish surnames, in lines of 10.

- Names and surnames were sourced from reputable databases including the INE, RAE, Forebears, Behind the Name, My Daily Spanish, and FamilyEducation. Cross-referenced to ensure consistency, and the URLs have been provided in the comments. 

- For Issue #16 