### PR TITLE
Added Portuguese names and surnames

### DIFF
--- a/src/names/pt.ts
+++ b/src/names/pt.ts
@@ -1,12 +1,11 @@
 
 const portugueseNames = {
     0: [ // Male names - https://www.familyeducation.com/, https://www.behindthename.com/, https://forebears.io/, https://www.ine.pt/, https://www.irn.mj.pt/
-        'Afonso', 'Alexandre', 'André', 'António', 'Bernardo', 'Carlos', 'Daniel', 'David', 'Diogo',
-        'Duarte', 'Eduardo', 'Fernando', 'Filipe', 'Francisco', 'Gabriel', 'Gonçalo', 'Gustavo', 'Henrique',
-        'Hugo', 'Ivan', 'João', 'José', 'Leonardo', 'Lucas', 'Luís', 'Manuel', 'Marcos', 'Mário',
-        'Mateus', 'Maurício', 'Miguel', 'Nicolas', 'Nuno', 'Paulo', 'Pedro', 'Rafael', 'Ricardo', 'Rodrigo',
-        'Rui', 'Salvador', 'Samuel', 'Santiago', 'Sérgio', 'Simão', 'Tiago', 'Tomás', 'Vasco', 'Vicente',
-        'Vítor', 'Xavier'
+        'Afonso', 'Alexandre', 'André', 'António', 'Bernardo', 'Carlos', 'Daniel', 'David', 'Diogo', 'Duarte',
+        'Eduardo', 'Fernando', 'Filipe', 'Francisco', 'Gabriel', 'Gonçalo', 'Gustavo', 'Henrique', 'Hugo', 'Ivan',
+        'João', 'José', 'Leonardo', 'Lucas', 'Luís', 'Manuel', 'Marcos', 'Mário', 'Mateus', 'Maurício',
+        'Miguel', 'Nicolas', 'Nuno', 'Paulo', 'Pedro', 'Rafael', 'Ricardo', 'Rodrigo', 'Rui', 'Salvador',
+        'Samuel', 'Santiago', 'Sérgio', 'Simão', 'Tiago', 'Tomás', 'Vasco', 'Vicente', 'Vítor', 'Xavier'
     ],
     1: [ // Female names - https://www.familyeducation.com/, https://www.behindthename.com/, https://forebears.io/, https://www.ine.pt/, https://www.irn.mj.pt/
         'Adriana', 'Alexa', 'Alice', 'Ana', 'Ana Sofia', 'Andreia', 'Bárbara', 'Beatriz', 'Beatriz Silva', 'Bianca',

--- a/src/names/pt.ts
+++ b/src/names/pt.ts
@@ -1,0 +1,21 @@
+
+const portugueseNames = {
+    0: [ // Male names - https://www.familyeducation.com/, https://www.behindthename.com/, https://forebears.io/, https://www.ine.pt/, https://www.irn.mj.pt/
+        'Afonso', 'Alexandre', 'André', 'António', 'Bernardo', 'Carlos', 'Daniel', 'David', 'Diogo',
+        'Duarte', 'Eduardo', 'Fernando', 'Filipe', 'Francisco', 'Gabriel', 'Gonçalo', 'Gustavo', 'Henrique',
+        'Hugo', 'Ivan', 'João', 'José', 'Leonardo', 'Lucas', 'Luís', 'Manuel', 'Marcos', 'Mário',
+        'Mateus', 'Maurício', 'Miguel', 'Nicolas', 'Nuno', 'Paulo', 'Pedro', 'Rafael', 'Ricardo', 'Rodrigo',
+        'Rui', 'Salvador', 'Samuel', 'Santiago', 'Sérgio', 'Simão', 'Tiago', 'Tomás', 'Vasco', 'Vicente',
+        'Vítor', 'Xavier'
+    ],
+    1: [ // Female names - https://www.familyeducation.com/, https://www.behindthename.com/, https://forebears.io/, https://www.ine.pt/, https://www.irn.mj.pt/
+        'Adriana', 'Alexa', 'Alice', 'Ana', 'Ana Sofia', 'Andreia', 'Bárbara', 'Beatriz', 'Beatriz Silva', 'Bianca',
+        'Carina', 'Carla', 'Carolina', 'Catarina', 'Clara', 'Cláudia', 'Cristina', 'Daniela', 'Diana', 'Diana Catarina',
+        'Diana Sofia', 'Eva', 'Filipa', 'Francisca', 'Gabriela', 'Inês', 'Isabel', 'Jéssica', 'Joana', 'Juliana',
+        'Lara', 'Laura', 'Leonor', 'Letícia', 'Lívia', 'Luana', 'Luna', 'Madalena', 'Margarida', 'Maria Carolina',
+        'Maria Francisca', 'Maria Inês', 'Maria Joana', 'Maria Leonor', 'Maria Luísa', 'Maria Margarida', 'Maria Sofia', 'Marta', 'Mariana', 'Mónica',
+        'Nádia', 'Nicole', 'Olivia', 'Patrícia', 'Sara', 'Sofia', 'Tatiana', 'Vanessa', 'Vera', 'Vitória'
+    ]
+}
+
+export default portugueseNames;

--- a/src/surnames/pt.ts
+++ b/src/surnames/pt.ts
@@ -1,0 +1,11 @@
+const portugueseSurnames = [ // https://www.behindthename.com/, https://surnam.es/, https://forebears.io/, https://www.ine.pt/, https://www.irn.mj.pt/
+    'Abreu', 'Alves', 'Andrade', 'Amaral', 'Amorim', 'Azevedo', 'Barbosa', 'Barroso', 'Bento', 'Bernardo',
+    'Brandão', 'Cabral', 'Cardoso', 'Carvalho', 'Castro', 'Coelho', 'Correia', 'Costa', 'Costa Silva', 'Cunha',
+    'Dias', 'Duarte', 'Fernandes', 'Fernandes Gonçalves', 'Ferreira', 'Ferreira da Silva', 'Ferreira Pinto', 'Figueiredo', 'Fonseca', 'Gomes',
+    'Gonçalves', 'Gonçalves Costa', 'Leitão', 'Lima', 'Lopes', 'Lopes da Silva', 'Machado', 'Marques', 'Martins', 'Martins Silva',
+    'Mendes', 'Miranda', 'Monteiro', 'Morais', 'Moreira', 'Nunes', 'Oliveira', 'Oliveira Costa', 'Oliveira Silva', 'Pereira',
+    'Pereira da Silva', 'Pereira Pinto', 'Pinto', 'Pinto Costa', 'Pinto Silva', 'Ramalho', 'Rodrigues', 'Santos', 'Silva', 'Silva Costa',
+    'Silva Oliveira', 'Silva Pinto', 'Sousa', 'Sousa Dias', 'Sousa Lopes', 'Sousa Martins', 'Teixeira', 'Vasconcelos', 'Vieira'
+];
+
+export default portugueseSurnames;


### PR DESCRIPTION
- Added Portuguese names and surnames. Cross-referenced multiple reputable sources to ensure accuracy and appropriateness of the data. Part of my Hacktoberfest contributions.
- https://www.familyeducation.com/, https://surnam.es/, https://www.behindthename.com/, https://forebears.io/, https://www.ine.pt/, https://www.irn.mj.pt/
- For Issue #14 