### PR TITLE
fix incorrect male portuguese first names

### DIFF
--- a/src/names/pt.ts
+++ b/src/names/pt.ts
@@ -1,9 +1,10 @@
 const portugueseNames = {
     0: [  // https://web.archive.org/web/20231016204629/https://pt.wikipedia.org/wiki/Antropon%C3%ADmia_da_l%C3%ADngua_portuguesa
-        'Afonso', 'Alexandre', 'Alfredo', 'Antônio', 'Bárbara', 'Camila', 'Carlos', 'Daniel', 'Diogo', 'Eduardo',
+        //https://irn.justica.gov.pt/Portals/33/Regras%20Nome%20Proprio/Lista%20Nomes%20Pr%C3%B3prios.pdf?ver=WNDmmwiSO3uacofjmNoxEQ%3D%3D
+        'Afonso', 'Alexandre', 'Alfredo', 'António', 'Bernardo', 'Carlos', 'Cristiano', 'Daniel', 'Diogo', 'Eduardo',
         'Fábio', 'Fernando', 'Filipe', 'Francisco', 'Frederico', 'Gabriel', 'Gonçalo', 'Guilherme', 'Gustavo', 'Henrique',
-        'Horácio', 'Jaime', 'João', 'Joaquim', 'Jorge', 'José', 'Júlia', 'Leonardo', 'Luís', 'Lúcia',
-        'Manuel', 'Marcos', 'Miguel', 'Nélson', 'Nicolau', 'Otávio', 'Osvaldo', 'Paulo', 'Pedro', 'Rafael',
+        'Horácio', 'Jaime', 'João', 'Joaquim', 'Jorge', 'José', 'Júlio', 'Leonardo', 'Lourenço', 'Luís',
+        'Manuel', 'Mário', 'Miguel', 'Nélson', 'Nicolau', 'Otávio', 'Osvaldo', 'Paulo', 'Pedro', 'Rafael',
         'Ricardo', 'Roberto', 'Rodrigo', 'Rodolfo', 'Rui', 'Sebastião', 'Sérgio', 'Tiago', 'Tomé', 'Vítor',
     ],
     1: [ // https://web.archive.org/web/20231016204629/https://pt.wikipedia.org/wiki/Antropon%C3%ADmia_da_l%C3%ADngua_portuguesa


### PR DESCRIPTION
Fixed some incorrect names 
Source of truth: //https://irn.justica.gov.pt/Portals/33/Regras%20Nome%20Proprio/Lista%20Nomes%20Pr%C3%B3prios.pdf?ver=WNDmmwiSO3uacofjmNoxEQ%3D%3D